### PR TITLE
Remove the hard-coded path to my home directory

### DIFF
--- a/src/tarch/tree.py
+++ b/src/tarch/tree.py
@@ -222,7 +222,7 @@ class FileChooserScreen(ModalScreen[pathlib.Path]):
     def compose(self) -> ComposeResult:
         with Center():
             yield Label("Destination")
-            yield OnlyDirectoryTree(pathlib.Path("/home/diazona"))
+            yield OnlyDirectoryTree(pathlib.Path.home())
             yield Input()
 
     def on_input_submitted(self, event: Input.Submitted) -> None:


### PR DESCRIPTION
This gets rid of the one last thing (I think) that makes the script specific to my system.